### PR TITLE
Fix typo with size estimation for segment tree

### DIFF
--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -44,7 +44,7 @@ Here is a visual representation of such a Segment Tree over the array $a = [1, 3
 
 From this short description of the data structure, we can already conclude that a Segment Tree only requires a linear number of vertices. 
 The first level of the tree contains a single node (the root), the second level will contain two vertices, in the third it will contain four vertices, until the number of vertices reaches $n$. 
-Thus the number of vertices in the worst case can be estimated by the sum $1 + 2 + 4 + \dots + 2^{\lceil\log_2 n\rceil} \lt 2^{\lceil\log_2 n\rceil + 1} = 4n$.
+Thus the number of vertices in the worst case can be estimated by the sum $1 + 2 + 4 + \dots + 2^{\lceil\log_2 n\rceil} \lt 2^{\lceil\log_2 n\rceil + 1} \lt 4n$.
 
 It is worth noting that whenever $n$ is not a power of two, not all levels of the Segment Tree will be completely filled. 
 We can see that behavior in the image.

--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -44,7 +44,7 @@ Here is a visual representation of such a Segment Tree over the array $a = [1, 3
 
 From this short description of the data structure, we can already conclude that a Segment Tree only requires a linear number of vertices. 
 The first level of the tree contains a single node (the root), the second level will contain two vertices, in the third it will contain four vertices, until the number of vertices reaches $n$. 
-Thus the number of vertices in the worst case can be estimated by the sum $1 + 2 + 4 + \dots + 2^{\lceil\log_2 n\rceil} = 2^{\lceil\log_2 n\rceil + 1} \lt 4n$.
+Thus the number of vertices in the worst case can be estimated by the sum $1 + 2 + 4 + \dots + 2^{\lceil\log_2 n\rceil} \lt 2^{\lceil\log_2 n\rceil + 1} = 4n$.
 
 It is worth noting that whenever $n$ is not a power of two, not all levels of the Segment Tree will be completely filled. 
 We can see that behavior in the image.


### PR DESCRIPTION
`1+2+4+...2^ceil(log_2(n))` is less than `2^(ceil(log_2(n))+1)`
E.g. `n=5`, left side is `1+2+4+8=15`, and right side is `2^(3+1)=16`